### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Stories in Ready](https://badge.waffle.io/MatterCraft/MatterCraft.png?label=ready&title=Ready)](https://waffle.io/MatterCraft/MatterCraft?utm_source=badge)
 [![Build Status](https://travis-ci.org/MatterCraft/MatterCraft.svg?branch=master)](https://travis-ci.org/MatterCraft/MatterCraft)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/MatterCraft/MatterCraft

This was requested by a real person (user kingdevnl) on waffle.io, we're not trying to spam you.